### PR TITLE
Separate InternalFrame.index_map into index_spark_column_names and index_names.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -17,7 +17,6 @@
 Koalas specific features.
 """
 import inspect
-from collections import OrderedDict
 from distutils.version import LooseVersion
 from typing import Any, Tuple, Union, TYPE_CHECKING
 import types
@@ -173,12 +172,11 @@ class KoalasFrameMethods(object):
         return DataFrame(
             InternalFrame(
                 spark_frame=sdf,
-                index_map=OrderedDict(
-                    [
-                        (SPARK_INDEX_NAME_FORMAT(i), name)
-                        for i, name in enumerate(internal.index_names)
-                    ]
-                ),
+                index_spark_column_names=[
+                    SPARK_INDEX_NAME_FORMAT(i)
+                    for i in range(len(internal.index_spark_column_names))
+                ],
+                index_names=internal.index_names,
                 column_labels=internal.column_labels + [column],
                 data_spark_columns=(
                     [scol_for(sdf, name_like_string(label)) for label in internal.column_labels]
@@ -388,7 +386,7 @@ class KoalasFrameMethods(object):
                 )
 
             # Otherwise, it loses index.
-            internal = InternalFrame(spark_frame=sdf, index_map=None)
+            internal = InternalFrame(spark_frame=sdf, index_spark_column_names=None)
 
         return DataFrame(internal)
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -18,7 +18,6 @@
 Base and utility classes for Koalas objects.
 """
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 import datetime
 from functools import wraps, partial
 from typing import Any, Callable, Tuple, Union
@@ -1335,7 +1334,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         internal = InternalFrame(
             spark_frame=sdf,
-            index_map=OrderedDict({index_name: None}),
+            index_spark_column_names=[index_name],
             column_labels=self._internal.column_labels,
             data_spark_columns=[scol_for(sdf, "count")],
             column_label_names=self._internal.column_label_names,

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -18,7 +18,6 @@
 A loc indexer for Koalas DataFrame/Series.
 """
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 from collections.abc import Iterable
 from functools import reduce
 from typing import Any, Optional, List, Tuple, TYPE_CHECKING
@@ -438,10 +437,12 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
         if remaining_index is not None:
             index_scols = self._internal.index_spark_columns[-remaining_index:]
-            index_map = OrderedDict(list(self._internal.index_map.items())[-remaining_index:])
+            index_spark_column_names = self._internal.index_spark_column_names[-remaining_index:]
+            index_names = self._internal.index_names[-remaining_index:]
         else:
             index_scols = self._internal.index_spark_columns
-            index_map = self._internal.index_map
+            index_spark_column_names = self._internal.index_spark_column_names
+            index_names = self._internal.index_names
 
         if len(column_labels) > 0:
             column_labels = column_labels.copy()
@@ -487,7 +488,8 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
         internal = InternalFrame(
             spark_frame=sdf,
-            index_map=index_map,
+            index_spark_column_names=index_spark_column_names,
+            index_names=index_names,
             column_labels=column_labels,
             data_spark_columns=data_spark_columns,
             column_label_names=column_label_names,

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from collections import OrderedDict
 import itertools
 
 import pandas as pd
@@ -265,10 +264,9 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
     def test_get_index_map(self):
         kdf = ks.DataFrame({"year": [2015, 2016], "month": [2, 3], "day": [4, 5]})
         sdf = kdf.to_spark()
-        self.assertIsNone(_get_index_map(sdf))
-        self.assertEqual(_get_index_map(sdf, "year"), OrderedDict([("year", ("year",))]))
+        self.assertEqual(_get_index_map(sdf), (None, None))
+        self.assertEqual(_get_index_map(sdf, "year"), (["year"], [("year",)]))
         self.assertEqual(
-            _get_index_map(sdf, ["year", "month"]),
-            OrderedDict([("year", ("year",)), ("month", ("month",))]),
+            _get_index_map(sdf, ["year", "month"]), (["year", "month"], [("year",), ("month",)])
         )
         self.assertRaises(KeyError, lambda: _get_index_map(sdf, ["year", "hour"]))

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -124,12 +124,7 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
             )
             return internal.copy(
                 spark_frame=sdf,
-                index_map=OrderedDict(
-                    zip(
-                        [rename(col) for col in internal.index_spark_column_names],
-                        internal.index_names,
-                    )
-                ),
+                index_spark_column_names=[rename(col) for col in internal.index_spark_column_names],
                 data_spark_columns=[
                     scol_for(sdf, rename(col)) for col in internal.data_spark_column_names
                 ],
@@ -218,7 +213,8 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
         return DataFrame(
             InternalFrame(
                 spark_frame=joined_df,
-                index_map=OrderedDict(zip(index_column_names, this_internal.index_names)),
+                index_spark_column_names=index_column_names,
+                index_names=this_internal.index_names,
                 column_labels=column_labels,
                 data_spark_columns=[scol_for(joined_df, col) for col in new_data_columns],
                 column_label_names=column_label_names,

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -699,7 +699,8 @@ class RollingGroupby(Rolling):
 
         internal = kdf._internal.copy(
             spark_frame=sdf,
-            index_map=new_index_map,
+            index_spark_column_names=list(new_index_map.keys()),
+            index_names=list(new_index_map.values()),
             column_labels=[c._column_label for c in applied],
             data_spark_columns=[
                 scol_for(sdf, c._internal.data_spark_column_names[0]) for c in applied


### PR DESCRIPTION
Recreated from original PR: https://github.com/databricks/koalas/pull/1879

Separates `InternalFrame.index_map` into `index_spark_column_names` and `index_names` to make them clearer.